### PR TITLE
Use system python instead of relying on user's PATH

### DIFF
--- a/usr/local/bin/arcolinux-welcome-app
+++ b/usr/local/bin/arcolinux-welcome-app
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python3 /usr/share/arcolinux-welcome-app/arcolinux-welcome-app.py
+/usr/bin/python3 /usr/share/arcolinux-welcome-app/arcolinux-welcome-app.py


### PR DESCRIPTION
Hi, the shim for `arcolinux-welcome-app` looks like it hasn't been touched in a few years, so I'm surprised I'm the first person to have this issue. Easy fix. Any method that allows `import gi` at the start of the session will fix the shim :)

I argue that we should just use the system python, since it's what we mean.

```
/usr/share/arcolinux-welcome-app►python conflicts.py
Traceback (most recent call last):
  File "/usr/share/arcolinux-welcome-app/conflicts.py", line 5, in <module>
    import gi
ModuleNotFoundError: No module named 'gi'
```

I use pyenv, and pretty aggressively put its shims first in my $PATH and as you can see, I like to keep my site-packages pure:

```
/usr/share/arcolinux-welcome-app►which python
/home/brian/.pyenv/shims/python
/usr/share/arcolinux-welcome-app►python3 -m pip freeze
/usr/share/arcolinux-welcome-app►         
```

No problem with system python doing whatever it wants; that's why I do what I do! But here is what arcolinux's pip freeze looks like:

```
/usr/share/arcolinux-welcome-app►/usr/bin/python3 -m pip freeze
annotated-types==0.6.0
apparmor==3.1.7
appdirs==1.4.4
...
pycairo==1.25.1
...
PyGObject==3.46.0
...
zstandard==0.22.0
/usr/share/arcolinux-welcome-app►/usr/bin/python3 -m pip freeze | count
150
```

Indeed, I found that this works, if I do it in any python environment:

```
pip install pycairo PyGObject
```

Clearly not a solution. While on the other hand, depending on a python3 that you put there is totally fair to everyone. Especially for the welcome application that must ALWAYS work.

We could make this a "real python package," and at least catch it sooner, in the future. I'd be happy to contribute! But for now, I believe this is good stuff. It is also the obviously intended behavior when using the shim.